### PR TITLE
Explicitly require `error.rb`

### DIFF
--- a/lib/geonames_api.rb
+++ b/lib/geonames_api.rb
@@ -42,6 +42,7 @@ module GeoNamesAPI
 end
 
 require 'geonames_api/version' # explicit require version file because it doesn't contain any class which can be autoload
+require 'geonames_api/error' # explicit require error file because it defines several other classes that won't be autoloaded
 Dir[File.dirname(__FILE__) + '/geonames_api/*.rb'].each do |file|
   tgt = File.basename(file, File.extname(file))
   GeoNamesAPI.autoload tgt.camelize, "geonames_api/#{tgt}"


### PR DESCRIPTION
`error.rb` file contains several class definitions that won't be autoloaded

```
irb(main):001:0> GeoNamesAPI::NoResultFound
NameError: uninitialized constant GeoNamesAPI::NoResultFound
       	from (irb):1
       	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-4.0.13/lib/rails/commands/console.rb:90:in `start'
       	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-4.0.13/lib/rails/commands/console.rb:9:in `start'
       	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-4.0.13/lib/rails/commands.rb:62:in `<top (required)>'
       	from /Users/person/project/bin/rails:10:in `<top (required)>'
       	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
       	from /usr/local/opt/rbenv/versions/2.2.4/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
       	from -e:1:in `<main>'
irb(main):002:0> GeoNamesAPI::Error
=> GeoNamesAPI::Error
irb(main):003:0> GeoNamesAPI::NoResultFound
=> GeoNamesAPI::NoResultFound
```

This should fix that